### PR TITLE
Clean the way the engine is used when compiling the tag

### DIFF
--- a/src/Aptoma/Twig/Extension/MarkdownExtension.php
+++ b/src/Aptoma/Twig/Extension/MarkdownExtension.php
@@ -56,7 +56,7 @@ class MarkdownExtension extends \Twig_Extension
      */
     public function getTokenParsers()
     {
-        return array(new MarkdownTokenParser($this->markdownEngine));
+        return array(new MarkdownTokenParser());
     }
 
     /**

--- a/src/Aptoma/Twig/Node/MarkdownNode.php
+++ b/src/Aptoma/Twig/Node/MarkdownNode.php
@@ -33,6 +33,6 @@ class MarkdownNode extends \Twig_Node
             ->write('$lines = explode("\n", $content);' . PHP_EOL)
             ->write('$content = preg_replace(\'/^\' . $matches[0]. \'/\', "", $lines);' . PHP_EOL)
             ->write('$content = join("\n", $content);' . PHP_EOL)
-            ->write('echo $this->env->getTokenParsers()->getTokenParser(\'markdown\')->getEngine()->transform($content);' . PHP_EOL);
+            ->write('echo $this->env->getExtension(\'markdown\')->parseMarkdown($content);' . PHP_EOL);
     }
 }

--- a/src/Aptoma/Twig/TokenParser/MarkdownTokenParser.php
+++ b/src/Aptoma/Twig/TokenParser/MarkdownTokenParser.php
@@ -3,7 +3,6 @@
 namespace Aptoma\Twig\TokenParser;
 
 use Aptoma\Twig\Node\MarkdownNode;
-use Aptoma\Twig\Extension\MarkdownEngineInterface;
 
 /**
  * @author Gunnar Lium <gunnar@aptoma.com>
@@ -12,40 +11,12 @@ use Aptoma\Twig\Extension\MarkdownEngineInterface;
 class MarkdownTokenParser extends \Twig_TokenParser
 {
     /**
-     * @var The Markdown engine
-     */
-    protected $markdownEngine;
-
-    /**
-     * @param MarkdownEngineInterface $markdownEngine The Markdown parser engine
-     */
-    public function __construct(MarkdownEngineInterface $markdownEngine)
-    {
-        $this->markdownEngine = $markdownEngine;
-    }
-
-    /**
-     * Markdown parser engine getter
-     *
-     * @return MarkdownEngineInterface
-     */
-    public function getEngine()
-    {
-        return $this->markdownEngine;
-    }
-
-    /**
-     * Parses a token and returns a node.
-     *
-     * @param \Twig_Token $token A \Twig_Token instance
-     *
-     * @throws \Twig_Error_Syntax
-     * @return \Twig_NodeInterface A \Twig_NodeInterface instance
+     * {@inheritdoc}
      */
     public function parse(\Twig_Token $token)
     {
         $lineno = $token->getLine();
-        
+
         $this->parser->getStream()->expect(\Twig_Token::BLOCK_END_TYPE);
         $body = $this->parser->subparse(array($this, 'decideMarkdownEnd'), true);
         $this->parser->getStream()->expect(\Twig_Token::BLOCK_END_TYPE);
@@ -65,9 +36,7 @@ class MarkdownTokenParser extends \Twig_TokenParser
     }
 
     /**
-     * Gets the tag name associated with this token parser.
-     *
-     * @return string The tag name
+     * {@inheritdoc}
      */
     public function getTag()
     {

--- a/tests/Aptoma/Twig/TokenParser/MarkdownTokenParserTest.php
+++ b/tests/Aptoma/Twig/TokenParser/MarkdownTokenParserTest.php
@@ -79,7 +79,7 @@ preg_match("/^\s*/", \$content, \$matches);
 \$lines = explode("\\n", \$content);
 \$content = preg_replace('/^' . \$matches[0]. '/', "", \$lines);
 \$content = join("\\n", \$content);
-echo \$this->env->getTokenParsers()->getTokenParser('markdown')->getEngine()->transform(\$content);
+echo \$this->env->getExtension('markdown')->parseMarkdown(\$content);
 EOF
             );
 
@@ -100,7 +100,7 @@ preg_match("/^\s*/", \$content, \$matches);
 \$lines = explode("\\n", \$content);
 \$content = preg_replace('/^' . \$matches[0]. '/', "", \$lines);
 \$content = join("\\n", \$content);
-echo \$this->env->getTokenParsers()->getTokenParser('markdown')->getEngine()->transform(\$content);
+echo \$this->env->getExtension('markdown')->parseMarkdown(\$content);
 EOF
         );
 


### PR DESCRIPTION
Accessing token parsers are runtime is a very bad idea (and may become forbidden in Twig 2). The implementation now relies on the extension to access the engine.