### PR TITLE
Change the typehint to prepare for Twig 2

### DIFF
--- a/src/Aptoma/Twig/Node/MarkdownNode.php
+++ b/src/Aptoma/Twig/Node/MarkdownNode.php
@@ -12,7 +12,7 @@ namespace Aptoma\Twig\Node;
  */
 class MarkdownNode extends \Twig_Node
 {
-    public function __construct(\Twig_NodeInterface $body, $lineno, $tag = 'markdown')
+    public function __construct(\Twig_Node $body, $lineno, $tag = 'markdown')
     {
         parent::__construct(array('body' => $body), array(), $lineno, $tag);
     }


### PR DESCRIPTION
Twig_NodeInterface is deprecated. All nodes must extend Twig_Node, and it should be used for typehints. Twig 2 is removing the interface entirely