### PR TITLE
Now you can pass configuration options to Michelf Markdown Engine

### DIFF
--- a/src/Aptoma/Twig/Extension/MarkdownEngine/MichelfMarkdownEngine.php
+++ b/src/Aptoma/Twig/Extension/MarkdownEngine/MichelfMarkdownEngine.php
@@ -19,7 +19,13 @@ class MichelfMarkdownEngine implements MarkdownEngineInterface
      */
     public function transform($content)
     {
-        return MarkdownExtra::defaultTransform($content);
+        $engine = new MarkdownExtra();
+        foreach (get_object_vars($this) as $property => $value) {
+            if (property_exists($engine, $property)) {
+                $engine->{$property} = $value;
+            }
+        }
+        return $engine->transform($content);
     }
 
     /**


### PR DESCRIPTION
Before, it was calling a static function `defaultTransform` so you wasn't be able to pass any configuration to engine.

Example:

``` php
  $markdownEngine = new MarkdownEngine\MichelfMarkdownEngine();
  $markdownEngine->header_id_func = function ($header) {
      return preg_replace('/[^a-z0-9]/', '-', strtolower($header));
  };
  $view->addExtension(new MarkdownExtension($markdownEngine));
```
