### PR TITLE
Upgrade to twig 2.7 and namespace

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 CHANGELOG
 =========
 
+Unreleased
+-----
+
+Upgrade to twig 2.7 and namespace, due to [a security issue](https://symfony.com/blog/twig-sandbox-information-disclosure)
+
 2.0.0
 -----
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
     "require": {
         "php": "^7.0",
-        "twig/twig": "^2.0"
+        "twig/twig": "^2.7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~6.0||~5.0",

--- a/src/Aptoma/Twig/Extension/MarkdownExtension.php
+++ b/src/Aptoma/Twig/Extension/MarkdownExtension.php
@@ -10,7 +10,7 @@ use Aptoma\Twig\TokenParser\MarkdownTokenParser;
  * @author Gunnar Lium <gunnar@aptoma.com>
  * @author Joris Berthelot <joris@berthelot.tel>
  */
-class MarkdownExtension extends \Twig_Extension
+class MarkdownExtension extends \Twig\Extension\AbstractExtension
 {
 
     /**
@@ -32,7 +32,7 @@ class MarkdownExtension extends \Twig_Extension
     public function getFilters()
     {
         return array(
-            new \Twig_Filter(
+            new \Twig\TwigFilter(
                 'markdown',
                 array($this, 'parseMarkdown'),
                 array('is_safe' => array('html'))

--- a/src/Aptoma/Twig/Node/MarkdownNode.php
+++ b/src/Aptoma/Twig/Node/MarkdownNode.php
@@ -10,9 +10,9 @@ namespace Aptoma\Twig\Node;
  * @author Gunnar Lium <gunnar@aptoma.com>
  * @author Joris Berthelot <joris@berthelot.tel>
  */
-class MarkdownNode extends \Twig_Node
+class MarkdownNode extends \Twig\Node\Node
 {
-    public function __construct(\Twig_Node $body, $lineno, $tag = 'markdown')
+    public function __construct(\Twig\Node\Node $body, $lineno, $tag = 'markdown')
     {
         parent::__construct(array('body' => $body), array(), $lineno, $tag);
     }
@@ -20,9 +20,9 @@ class MarkdownNode extends \Twig_Node
     /**
      * Compiles the node to PHP.
      *
-     * @param \Twig_Compiler A Twig_Compiler instance
+     * @param \Twig\Compiler A Twig\Compiler instance
      */
-    public function compile(\Twig_Compiler $compiler)
+    public function compile(\Twig\Compiler $compiler)
     {
         $compiler
             ->addDebugInfo($this)

--- a/src/Aptoma/Twig/TokenParser/MarkdownTokenParser.php
+++ b/src/Aptoma/Twig/TokenParser/MarkdownTokenParser.php
@@ -8,18 +8,18 @@ use Aptoma\Twig\Node\MarkdownNode;
  * @author Gunnar Lium <gunnar@aptoma.com>
  * @author Joris Berthelot <joris@berthelot.tel>
  */
-class MarkdownTokenParser extends \Twig_TokenParser
+class MarkdownTokenParser extends \Twig\TokenParser\AbstractTokenParser
 {
     /**
      * {@inheritdoc}
      */
-    public function parse(\Twig_Token $token)
+    public function parse(\Twig\Token $token)
     {
         $lineno = $token->getLine();
 
-        $this->parser->getStream()->expect(\Twig_Token::BLOCK_END_TYPE);
+        $this->parser->getStream()->expect(\Twig\Token::BLOCK_END_TYPE);
         $body = $this->parser->subparse(array($this, 'decideMarkdownEnd'), true);
-        $this->parser->getStream()->expect(\Twig_Token::BLOCK_END_TYPE);
+        $this->parser->getStream()->expect(\Twig\Token::BLOCK_END_TYPE);
 
         return new MarkdownNode($body, $lineno, $this->getTag());
     }
@@ -27,10 +27,10 @@ class MarkdownTokenParser extends \Twig_TokenParser
     /**
      * Decide if current token marks end of Markdown block.
      *
-     * @param \Twig_Token $token
+     * @param \Twig\Token $token
      * @return bool
      */
-    public function decideMarkdownEnd(\Twig_Token $token)
+    public function decideMarkdownEnd(\Twig\Token $token)
     {
         return $token->test('endmarkdown');
     }

--- a/tests/Aptoma/Twig/Extension/MarkdownExtensionTest.php
+++ b/tests/Aptoma/Twig/Extension/MarkdownExtensionTest.php
@@ -33,8 +33,8 @@ class MarkdownExtensionTest extends TestCase
 
     protected function getTemplate($template)
     {
-        $loader = new \Twig_Loader_Array(array('index' => $template));
-        $twig = new \Twig_Environment($loader, array('debug' => true, 'cache' => false));
+        $loader = new \Twig\Loader\ArrayLoader(array('index' => $template));
+        $twig = new \Twig\Environment($loader, array('debug' => true, 'cache' => false));
         $twig->addExtension(new MarkdownExtension($this->getEngine()));
 
         return $twig->load('index');

--- a/tests/Aptoma/Twig/TokenParser/MarkdownTokenParserTest.php
+++ b/tests/Aptoma/Twig/TokenParser/MarkdownTokenParserTest.php
@@ -5,10 +5,11 @@ namespace Aptoma\Twig\TokenParser;
 use Aptoma\Twig\Extension\MarkdownEngine\MichelfMarkdownEngine;
 use Aptoma\Twig\Node\MarkdownNode;
 use PHPUnit\Framework\TestCase;
-use Twig_Compiler;
-use Twig_Environment;
-use Twig_Loader_Array;
-use Twig_Node;
+use Twig\Compiler;
+use Twig\Environment;
+use Twig\Loader\ArrayLoader;
+use Twig\Node\Node;
+use Twig\Node\TextNode;
 
 /**
  * @author Gunnar Lium <gunnar@aptoma.com>
@@ -17,7 +18,7 @@ class MarkdownTokenParserTest extends TestCase
 {
     public function testConstructor()
     {
-        $body = new \Twig_Node(array(new \Twig_Node_Text("#Title\n\nparagraph\n", 1)));
+        $body = new Node(array(new TextNode("#Title\n\nparagraph\n", 1)));
         $node = new MarkdownNode($body, 1);
 
         $this->assertEquals($body, $node->getNode('body'));
@@ -69,7 +70,7 @@ class MarkdownTokenParserTest extends TestCase
     {
         $tests = array();
 
-        $body = new \Twig_Node(array(new \Twig_Node_Text("#Title\n\nparagraph\n", 1)));
+        $body = new Node(array(new TextNode("#Title\n\nparagraph\n", 1)));
         $node = new MarkdownNode($body, 1);
 
         $tests['simple text'] = array($node, <<<EOF
@@ -88,7 +89,7 @@ echo \$this->env->getExtension('Aptoma\Twig\Extension\MarkdownExtension')->parse
 EOF
             );
 
-        $body = new \Twig_Node(array(new \Twig_Node_Text("    #Title\n\n    paragraph\n\n        code\n", 1)));
+        $body = new Node(array(new TextNode("    #Title\n\n    paragraph\n\n        code\n", 1)));
         $node = new MarkdownNode($body, 1);
 
         $tests['text with leading indent'] = array($node, <<<EOF
@@ -112,7 +113,7 @@ EOF
         return $tests;
     }
 
-    public function assertNodeCompilation($source, Twig_Node $node, Twig_Environment $environment = null, $isPattern = false)
+    public function assertNodeCompilation($source, Node $node, Environment $environment = null, $isPattern = false)
     {
         $compiler = $this->getCompiler($environment);
         $compiler->compile($node);
@@ -124,13 +125,13 @@ EOF
         }
     }
 
-    protected function getCompiler(Twig_Environment $environment = null)
+    protected function getCompiler(Environment $environment = null)
     {
-        return new Twig_Compiler(null === $environment ? $this->getEnvironment() : $environment);
+        return new Compiler(null === $environment ? $this->getEnvironment() : $environment);
     }
 
     protected function getEnvironment()
     {
-        return new Twig_Environment(new Twig_Loader_Array(array()));
+        return new Environment(new ArrayLoader(array()));
     }
 }


### PR DESCRIPTION
Upgrade to twig 2.7 and namespace, due to [a security issue](https://symfony.com/blog/twig-sandbox-information-disclosure)