### PR TITLE
Update ParsedownEngine to set HTML escaping

### DIFF
--- a/src/Aptoma/Twig/Extension/MarkdownEngine/ParsedownEngine.php
+++ b/src/Aptoma/Twig/Extension/MarkdownEngine/ParsedownEngine.php
@@ -42,4 +42,25 @@ class ParsedownEngine implements MarkdownEngineInterface
     {
         return 'erusev/parsedown';
     }
+    
+    /**
+     * Turn on/off escaping within the generated HTML. Should be
+     * turned on for untrusted user input.
+     *
+     * @param bool $bool Flag to set Safe Mode to
+     */
+    public function setSafeMode($bool)
+    {
+        $this->engine->setSafeMode($bool === true);
+    }
+    
+    /**
+     * Turn on/off escaping HTML in trusted user input.
+     *
+     * @param bool $bool Flag to set markup escaped to
+     */
+    public function setMarkupEscaped($bool)
+    {
+        $this->engine->setMarkupEscaped($bool === true);
+    }
 }

--- a/tests/Aptoma/Twig/Extension/MarkdownEngine/ParsedownEngineTest.php
+++ b/tests/Aptoma/Twig/Extension/MarkdownEngine/ParsedownEngineTest.php
@@ -2,6 +2,7 @@
 
 namespace Aptoma\Twig\Extension\MarkdownEngine;
 
+use Aptoma\Twig\Extension\MarkdownExtension;
 use Aptoma\Twig\Extension\MarkdownExtensionTest;
 
 // Require parent class if not autoloaded
@@ -28,5 +29,33 @@ class ParsedownEngineTest extends MarkdownExtensionTest
     protected function getEngine()
     {
         return new ParsedownEngine();
+    }
+
+    public function testSafeMode()
+    {
+        $engine = $this->getEngine();
+        $loader = new \Twig\Loader\ArrayLoader(array('index' => '{{ "_Test_<em>Test</em>[xss](javascript:alert%281%29)"|markdown }}'));
+        $twig = new \Twig\Environment($loader, array('debug' => true, 'cache' => false));
+        $twig->addExtension(new MarkdownExtension($engine));
+
+        $this->assertEquals('<p><em>Test</em><em>Test</em><a href="javascript:alert%281%29">xss</a></p>', $twig->load('index')->render());
+
+        $engine->setSafeMode(true);
+        $this->assertEquals('<p><em>Test</em>&lt;em&gt;Test&lt;/em&gt;<a href="javascript%3Aalert%281%29">xss</a></p>', $twig->load('index')->render());
+        $engine->setSafeMode(false);
+    }
+
+    public function testMarkupEscape()
+    {
+        $engine = $this->getEngine();
+        $loader = new \Twig\Loader\ArrayLoader(array('index' => '{{ "_Test_<em>Test</em>[xss](javascript:alert%281%29)"|markdown }}'));
+        $twig = new \Twig\Environment($loader, array('debug' => true, 'cache' => false));
+        $twig->addExtension(new MarkdownExtension($engine));
+
+        $this->assertEquals('<p><em>Test</em><em>Test</em><a href="javascript:alert%281%29">xss</a></p>', $twig->load('index')->render());
+
+        $engine->setMarkupEscaped(true);
+        $this->assertEquals('<p><em>Test</em>&lt;em&gt;Test&lt;/em&gt;<a href="javascript:alert%281%29">xss</a></p>', $twig->load('index')->render());        
+        $engine->setMarkupEscaped(false);
     }
 }


### PR DESCRIPTION
This makes it possible to set options on the underlying engine on how it should handle escaping HTML, which I found necessary for a project which was using untrusted user input.