### PR TITLE
Update Travis to test on more PHP versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,8 @@
 language: php
 php:
   - 7.1
+  - 7.2
+  - 7.3
 
 install:
   - composer install -n


### PR DESCRIPTION
PHP 7.1 is currently only under security support, while PHP 7.2 and 7.3 are under active development. It would be good to see this library get tested against these versions.

Source: https://www.php.net/supported-versions.php