### PR TITLE
Remove invalid phpunit setting

### DIFF
--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -7,7 +7,6 @@
          convertWarningsToExceptions="true"
          processIsolation="false"
          stopOnFailure="false"
-         syntaxCheck="false"
          bootstrap="vendor/autoload.php"
 >
     <testsuites>


### PR DESCRIPTION
The `syntaxCheck` setting was removed from phpunit [long ago](https://stackoverflow.com/a/44331140/4616655). On newer versions, phpunit will output that a warning that the configuration file did not pass validation due to this field. Removing it then should have no effect on the test suite or library at large.