### PR TITLE
Fix README example for MarkdownTokenParser

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,12 +118,9 @@ $twig->addExtension(new MarkdownExtension($engine));
 The Twig token parser provides the `markdown` tag only!
 
 ```php
-use Aptoma\Twig\Extension\MarkdownEngine;
 use Aptoma\Twig\TokenParser\MarkdownTokenParser;
 
-$engine = new MarkdownEngine\MichelfMarkdownEngine();
-
-$twig->addTokenParser(new MarkdownTokenParser($engine));
+$twig->addTokenParser(new MarkdownTokenParser());
 ```
 
 ### Symfony


### PR DESCRIPTION
This fixes the issue that the README example for the MarkdownTokenParser was incorrect in the README as pointed out in #27.