### PR TITLE
Define implements ExtensionInterface

### DIFF
--- a/src/Aptoma/Twig/Extension/MarkdownExtension.php
+++ b/src/Aptoma/Twig/Extension/MarkdownExtension.php
@@ -10,7 +10,7 @@ use Aptoma\Twig\TokenParser\MarkdownTokenParser;
  * @author Gunnar Lium <gunnar@aptoma.com>
  * @author Joris Berthelot <joris@berthelot.tel>
  */
-class MarkdownExtension extends \Twig\Extension\AbstractExtension
+class MarkdownExtension extends \Twig\Extension\AbstractExtension implements \Twig\Extension\ExtensionInterface
 {
 
     /**


### PR DESCRIPTION
I am using PHP intelephense to analyze my code. it is throwing errors because it does not know that MarkdownExtension implements ExtensionInterface. Explicitly adding this fixes those errors.